### PR TITLE
Feat/mainnet deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .aptos/
 build/
 .aptos-*/
+service-account

--- a/Move.toml
+++ b/Move.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 authors = []
 
 [addresses]
-aptree="0x057e530743cc8058dad22ca6c1ba6a17cdf63e7fb61624085b9d6ca9dcae49e8"
-
+aptree="0x4e490c26efe98a90bbffb869d7c54c0e2bff390c8bc5b9f3582b4170f017c133"
+service_account="0xb80ceb8949f8afabdb60a56c14b43b583bb419eef51a0fe7ac8c65e00c458bee"
 [dev-addresses]
 
 [dependencies.AptosFramework]

--- a/sources/issuer.move
+++ b/sources/issuer.move
@@ -18,31 +18,28 @@ module aptree::issuer {
     use aptos_framework::coin;
     use aptos_framework::event::emit;
     use aptos_framework::object;
-    use aptos_token_objects::aptos_token::AptosToken;
     use aptos_token_objects::collection;
     use aptos_token_objects::token;
-    #[test_only]
-    use std::signer;
-    // #[test_only]
-    // use aptos_std::debug;
     #[test_only]
     use aptos_framework::timestamp;
 
     const SEED: vector<u8> = b"Aptree";
     const SEED_REGISTRY_NAME: vector<u8> = b"Aptree Seed Nursery";
     const SEED_REGISTRY_DESCRIPTION: vector<u8> = b"A collection of seeds waiting to be planted. Each one holds the potential for growth but only action can unlock it. Plant your seed, and begin the journey.";
-    const SEED_REGISTY_IMAGE: vector<u8> = b"https://raw.githubusercontent.com/aptree-labs/registry/refs/heads/main/png/arcacia/background.png";
+    const SEED_REGISTY_IMAGE: vector<u8> = b"https://raw.githubusercontent.com/aptree-labs/registry/refs/heads/main/collection-refs/seed.jpg";
 
     const PLANTATION_REGISTRY_NAME: vector<u8> = b"Aptree Tree Plantation";
     const PLANTATION_REGISTRY_DESCRIPTION: vector<u8> = b"These seeds have been planted and are now growing. Water them daily, stay consistent, and watch them evolve into something meaningful.";
-    const PLANTATION_REGISTRY_IMAGE: vector<u8> = b"https://raw.githubusercontent.com/aptree-labs/registry/refs/heads/main/png/arcacia/background.png";
+    const PLANTATION_REGISTRY_IMAGE: vector<u8> = b"https://raw.githubusercontent.com/aptree-labs/registry/refs/heads/main/collection-refs/plantation.jpg";
 
-    const METADATA_BASE_URI: vector<u8> = b"https://drogen-development.up.railway.app/metadata";
+    const METADATA_BASE_URI: vector<u8> = b"https://preview-dropgen.aptree.io/metadata/plant";
 
     // Errors
     const EOperationNotPermitted: u64 = 403;
     const ERegistryUnInitialized: u64 = 404;
     const ESeedAlreadyPlantedOrDoesNotExist: u64 = 405;
+    const EServiceAccountInvalid: u64 = 406;
+    const EInvalidPlanterType: u64 = 407;
 
     struct Seed has key, store, drop {
         token_mutator_ref: token::MutatorRef,
@@ -65,6 +62,17 @@ module aptree::issuer {
     struct AddConsumable has store, drop {
         id: string::String,
         price: u64
+    }
+
+    #[event]
+    struct UpdatedConsumablePrice has store, drop {
+        id: string::String,
+        price: u64
+    }
+
+    #[event]
+    struct RemovedConsumable has store, drop {
+        id: string::String
     }
 
     #[event]
@@ -147,7 +155,7 @@ module aptree::issuer {
             signer_capability,
             metadata_base_uri: string::utf8(METADATA_BASE_URI),
             consumables: vector[],
-            treasury: signer::address_of(admin)
+            treasury: @service_account
         };
 
         move_to<TreeRegistry>(&resource_account_signer, registry);
@@ -233,7 +241,7 @@ module aptree::issuer {
 
     }
 
-    entry fun plant_seed(user: &signer, seed_name: string::String) acquires Seed, TreeRegistry {
+    fun plant_seed(user: &signer, seed_name: string::String) acquires Seed, TreeRegistry {
         let user_address = address_of(user);
         let resource_address = account::create_resource_address(&@aptree, SEED);
 
@@ -320,6 +328,26 @@ module aptree::issuer {
 
     }
 
+    public fun plant_v1(
+        user: &signer,
+        service_account: &signer,
+        seed_name: string::String,
+        planter_type: u64
+    ) acquires Seed, TreeRegistry {
+        assert!(address_of(service_account) == @service_account, EServiceAccountInvalid);
+        plant_seed(user, seed_name);
+
+        if (planter_type == 1) {
+            coin::transfer<AptosCoin>(user, @service_account, 10_000_000)
+        } else if (planter_type == 2) {
+            coin::transfer<AptosCoin>(user, @service_account, 50_000_000)
+        } else if (planter_type == 3) {
+            coin::transfer<AptosCoin>(user, @service_account, 100_000_000)
+        } else {
+            assert!(false, EInvalidPlanterType);
+        }
+    }
+
     entry fun create_consumable(
         admin: &signer, id: string::String, price: u64
     ) acquires TreeRegistry {
@@ -349,6 +377,43 @@ module aptree::issuer {
         coin::transfer<AptosCoin>(user, registry.treasury, consumable.price);
 
         emit(ConsumablePurchase { id, for: user_address })
+
+    }
+
+    entry fun update_consumable_price(
+        admin: &signer, id: string::String, price: u64
+    ) acquires TreeRegistry {
+        assert!(address_of(admin) == @aptree, EOperationNotPermitted);
+
+        let resource_address = account::create_resource_address(&@aptree, SEED);
+        let registry = borrow_global_mut<TreeRegistry>(resource_address);
+
+        let (exists, index) = vector::find(&registry.consumables, |c| c.id == id);
+
+        assert!(exists, EOperationNotPermitted);
+
+        let consumable = vector::borrow_mut(&mut registry.consumables, index);
+
+        consumable.price = price;
+
+        emit(UpdatedConsumablePrice { id, price });
+
+    }
+
+    entry fun remove_consumable(
+        admin: &signer, id: string::String, price: u64
+    ) acquires TreeRegistry {
+        assert!(address_of(admin) == @aptree, EOperationNotPermitted);
+
+        let resource_address = account::create_resource_address(&@aptree, SEED);
+        let registry = borrow_global_mut<TreeRegistry>(resource_address);
+
+        let (exists, index) = vector::find(&registry.consumables, |c| c.id == id);
+
+        assert!(exists, EOperationNotPermitted);
+
+        vector::remove(&mut registry.consumables, index);
+        emit(RemovedConsumable { id });
 
     }
 
@@ -477,12 +542,14 @@ module aptree::issuer {
 
         // 🌱 parameters for the new seed
         let specie = string::utf8(b"acacia");
+        let specie_name = string::utf8(b"Acacia");
         let seed_hash = string::utf8(b"hash123");
         let index = string::utf8(b"1");
         let recipient = signer::address_of(user);
 
         // 🪄  call entry
-        aptree::issuer::issue_seed(admin, recipient, seed_hash, specie, index);
+
+        issue_seed(admin, recipient, seed_hash, specie, specie_name, index);
 
         // 🔎 registry updates
         let reg_addr = account::create_resource_address(&@aptree, aptree::issuer::SEED);
@@ -492,7 +559,7 @@ module aptree::issuer {
         // 🔎 the seed object must exist and be owned by `recipient`
         // build expected seed name:  "acacia #1"
         let expected_name = string::utf8(b"");
-        string::append(&mut expected_name, specie);
+        string::append(&mut expected_name, specie_name);
         string::append(&mut expected_name, string::utf8(b" #"));
         string::append(&mut expected_name, index);
 
@@ -525,14 +592,15 @@ module aptree::issuer {
         let specie = string::utf8(b"acacia");
         let seed_hash = string::utf8(b"hash123");
         let index = string::utf8(b"1");
+        let specie_name = string::utf8(b"Acacia");
         let recipient = signer::address_of(user);
 
-        aptree::issuer::issue_seed(admin, recipient, seed_hash, specie, index);
+        aptree::issuer::issue_seed(admin, recipient, seed_hash, specie, specie_name, index);
 
         /* ── 4️⃣  User plants that same seed ─────────────────────────────── */
         // Build the seed's token-name string:  "acacia #1"
         let seed_name = string::utf8(b"");
-        string::append(&mut seed_name, specie);
+        string::append(&mut seed_name, specie_name);
         string::append(&mut seed_name, string::utf8(b" #"));
         string::append(&mut seed_name, index);
 


### PR DESCRIPTION
This pull request introduces several important updates to the `aptree::issuer` Move module and its configuration. The changes focus on improving collection metadata, adding new event types and admin functions for consumables, refactoring the seed planting logic, and updating references and error handling for enhanced security and clarity.

**Metadata and Address Updates**
* Updated addresses in `Move.toml` to reflect new `aptree` and introduce a `service_account` for treasury management.
* Refined collection and metadata constants for seeds and plantations, including new image URLs and a corrected base URI.

**Consumable Management Enhancements**
* Added new event structs: `UpdatedConsumablePrice` and `RemovedConsumable`, enabling tracking of consumable price changes and removals.
* Implemented `update_consumable_price` and `remove_consumable` entry functions for admin management of consumables, with appropriate permission checks and event emissions.

**Seed Planting and Treasury Logic**
* Changed the treasury address in `TreeRegistry` to use the new `service_account`.
* Added a new `plant_v1` entry function that enforces service account validation and supports planter types with corresponding payments.
* Refactored the original `plant_seed` function to be non-entry, now used internally for planting logic.

**Royalty and Collection Improvements**
* Introduced royalty support for plantations by creating and attaching a royalty object during collection creation.

**Testing and Naming Consistency**
* Updated test logic to use `specie_name` ("Acacia") instead of `specie` ("acacia") for seed naming, ensuring consistency in token names. [[1]](diffhunk://#diff-fa2b66ba2a6237d84132ac093ad4cd94615709a5294ea28aef620e559ca9154aR546-R560) [[2]](diffhunk://#diff-fa2b66ba2a6237d84132ac093ad4cd94615709a5294ea28aef620e559ca9154aL495-R570) [[3]](diffhunk://#diff-fa2b66ba2a6237d84132ac093ad4cd94615709a5294ea28aef620e559ca9154aR603-R618)