### PR TITLE
feat: plant_simple

### DIFF
--- a/.idea/aptree-contract.iml
+++ b/.idea/aptree-contract.iml
@@ -9,6 +9,5 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="orpheus" />
   </component>
 </module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/aptree-contract.iml" filepath="$PROJECT_DIR$/.idea/aptree-contract.iml" />
-      <module fileurl="file://$PROJECT_DIR$/../../kade/orpheus/.idea/orpheus.iml" filepath="$PROJECT_DIR$/../../kade/orpheus/.idea/orpheus.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../../kade/orpheus" vcs="Git" />
   </component>
 </project>

--- a/sources/issuer.move
+++ b/sources/issuer.move
@@ -351,6 +351,11 @@ module aptree::issuer {
         }
     }
 
+    public entry fun plant_simple(user: &signer, seed_name: string::String) acquires Seed, TreeRegistry {
+        plant_seed(user, seed_name);
+        coin::transfer<AptosCoin>(user, @service_account, 10_000_000);
+    }
+
     entry fun create_consumable(
         admin: &signer, id: string::String, price: u64
     ) acquires TreeRegistry {


### PR DESCRIPTION

Smart contract enhancement:

* Added a new public entry function `plant_simple` to the `aptree::issuer` module in `sources/issuer.move`, allowing users to plant a seed and automatically transfer 10_000_000 `AptosCoin` to the service account in a single call.